### PR TITLE
Enforce Content Types

### DIFF
--- a/app.py
+++ b/app.py
@@ -66,6 +66,7 @@ class Handler(BaseHTTPRequestHandler):
         exclude = [x for x in self._params.get('exclude', '').split(',') if x]
 
         self.send_response(200)
+        self.send_header('content-type', 'vnd.apple.mpegurl')
         self.end_headers()
 
         self.wfile.write(b'#EXTM3U\n')
@@ -101,7 +102,7 @@ class Handler(BaseHTTPRequestHandler):
     def _proxy(self, url):
         resp = requests.get(url)
         self.send_response(resp.status_code)
-        self.send_header('content-type', resp.headers.get('content-type'))
+        self.send_header('content-type', 'application/gzip')
         self.end_headers()
         for chunk in resp.iter_content(CHUNKSIZE):
             self.wfile.write(chunk)


### PR DESCRIPTION
This PR ensures that the correct content type is always returned when the files are requested to be downloaded, no matter how they are requested.

In my case, my endpoints are accessible externally, being routed through Cloudflare -> Nginx Proxy -> internal server. Nginx is configured to return the correct files when I access a standard URL, e.g. `https://iptv.domain.com/samsung/playlist` or `https://iptv.domain.com/samsung/epg`. When accessing the files this way, the browser is unaware of the file content type.

After these changes, proxy access with custom URLs works, and internal access still works as it did previously.